### PR TITLE
Simplify blending nnue complexity with optimism

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1070,10 +1070,8 @@ Value Eval::evaluate(const Position& pos) {
 
       Value nnue = NNUE::evaluate(pos, true, &nnueComplexity);
 
-      // Blend nnue complexity with (semi)classical complexity
-      nnueComplexity = 25 * (nnueComplexity + abs(psq - nnue)) / 64;
-
-      optimism += optimism * nnueComplexity / 256;
+      // Blend optimism with nnue complexity and (semi)classical complexity
+      optimism += 25 * optimism * (nnueComplexity + abs(psq - nnue)) / 16384;
       v = (nnue * (945 + npm) + optimism * (174 + npm)) / 1024;
   }
 


### PR DESCRIPTION
Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/6478a26d54dd118e1d98f21c
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 241248 W: 64058 L: 64063 D: 113127
Ptnml(0-2): 644, 26679, 65960, 26720, 621

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/647b464854dd118e1d9928b2
LLR: 2.96 (-2.94,2.94) <-1.75,0.25>
Total: 24336 W: 6658 L: 6451 D: 11227
Ptnml(0-2): 8, 2316, 7312, 2525, 7

bench 2452594